### PR TITLE
Factor out distance calculations for searchers in DistanceCalculator

### DIFF
--- a/include/klee/Module/TargetForest.h
+++ b/include/klee/Module/TargetForest.h
@@ -298,6 +298,7 @@ public:
   void add(ref<Target>);
   void remove(ref<Target>);
   void blockIn(ref<Target>, ref<Target>);
+  void block(const ref<Target> &);
   const ref<History> getHistory() { return history; };
   const ref<Layer> getTargets() { return forest; };
   void dump() const;

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -13,6 +13,7 @@ klee_add_component(kleeCore
   Context.cpp
   CoreStats.cpp
   CXXTypeSystem/CXXTypeManager.cpp
+  DistanceCalculator.cpp
   ExecutionState.cpp
   Executor.cpp
   ExecutorUtil.cpp

--- a/lib/Core/DistanceCalculator.cpp
+++ b/lib/Core/DistanceCalculator.cpp
@@ -1,0 +1,210 @@
+//===-- DistanceCalculator.cpp --------------------------------------------===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "DistanceCalculator.h"
+#include "ExecutionState.h"
+#include "klee/Module/CodeGraphDistance.h"
+#include "klee/Module/KInstruction.h"
+#include "klee/Module/Target.h"
+
+using namespace llvm;
+using namespace klee;
+
+DistanceResult DistanceCalculator::getDistance(ExecutionState &es,
+                                               ref<Target> target) {
+  return getDistance(es.pc, es.prevPC, es.initPC, es.stack, es.error, target);
+}
+
+DistanceResult
+DistanceCalculator::getDistance(KInstruction *pc, KInstruction *prevPC,
+                                KInstruction *initPC,
+                                const ExecutionState::stack_ty &stack,
+                                ReachWithError error, ref<Target> target) {
+  weight_type weight = 0;
+
+  BasicBlock *pcBlock = pc->inst->getParent();
+  BasicBlock *prevPCBlock = prevPC->inst->getParent();
+
+  if (!target->shouldFailOnThisTarget() && target->atReturn()) {
+    if (prevPC->parent == target->getBlock() &&
+        prevPC == target->getBlock()->getLastInstruction()) {
+      return DistanceResult(Done);
+    } else if (pc->parent == target->getBlock()) {
+      return DistanceResult(Continue);
+    }
+  }
+
+  if (target->shouldFailOnThisTarget() && target->isTheSameAsIn(prevPC) &&
+      target->isThatError(error)) {
+    return DistanceResult(Done);
+  }
+
+  BasicBlock *bb = pcBlock;
+  KBlock *kb = pc->parent->parent->blockMap[bb];
+  const auto &distanceToTargetFunction =
+      codeGraphDistance.getBackwardDistance(target->getBlock()->parent);
+  unsigned int minCallWeight = UINT_MAX, minSfNum = UINT_MAX, sfNum = 0;
+  for (auto sfi = stack.rbegin(), sfe = stack.rend(); sfi != sfe; sfi++) {
+    unsigned callWeight;
+    if (distanceInCallGraph(sfi->kf, kb, callWeight, distanceToTargetFunction,
+                            target)) {
+      callWeight *= 2;
+      if (callWeight == 0 && target->shouldFailOnThisTarget()) {
+        return target->isTheSameAsIn(kb->getFirstInstruction()) &&
+                       target->isThatError(error)
+                   ? DistanceResult(Done)
+                   : DistanceResult(Continue);
+      } else {
+        callWeight += sfNum;
+      }
+
+      if (callWeight < minCallWeight) {
+        minCallWeight = callWeight;
+        minSfNum = sfNum;
+      }
+    }
+
+    if (sfi->caller) {
+      kb = sfi->caller->parent;
+      bb = kb->basicBlock;
+    }
+    sfNum++;
+
+    if (minCallWeight < sfNum)
+      break;
+  }
+
+  WeightResult res = Miss;
+  bool isInsideFunction = true;
+  if (minCallWeight == 0) {
+    res = tryGetTargetWeight(pc, initPC, pcBlock, prevPCBlock, weight, target);
+  } else if (minSfNum == 0) {
+    res = tryGetPreTargetWeight(pc, initPC, pcBlock, prevPCBlock, weight,
+                                distanceToTargetFunction, target);
+    isInsideFunction = false;
+  } else if (minSfNum != UINT_MAX) {
+    res = tryGetPostTargetWeight(pc, initPC, pcBlock, prevPCBlock, weight,
+                                 target);
+    isInsideFunction = false;
+  }
+  if (Done == res && target->shouldFailOnThisTarget()) {
+    if (!target->isThatError(error)) {
+      res = Continue;
+    }
+  }
+
+  return DistanceResult(res, weight, isInsideFunction);
+}
+
+bool DistanceCalculator::distanceInCallGraph(
+    KFunction *kf, KBlock *kb, unsigned int &distance,
+    const std::unordered_map<KFunction *, unsigned int>
+        &distanceToTargetFunction,
+    ref<Target> target) {
+  distance = UINT_MAX;
+  const std::unordered_map<KBlock *, unsigned> &dist =
+      codeGraphDistance.getDistance(kb);
+  KBlock *targetBB = target->getBlock();
+  KFunction *targetF = targetBB->parent;
+
+  if (kf == targetF && dist.count(targetBB) != 0) {
+    distance = 0;
+    return true;
+  }
+
+  for (auto &kCallBlock : kf->kCallBlocks) {
+    if (dist.count(kCallBlock) != 0) {
+      for (auto &calledFunction : kCallBlock->calledFunctions) {
+        KFunction *calledKFunction = kf->parent->functionMap[calledFunction];
+        if (distanceToTargetFunction.count(calledKFunction) != 0 &&
+            distance > distanceToTargetFunction.at(calledKFunction) + 1) {
+          distance = distanceToTargetFunction.at(calledKFunction) + 1;
+        }
+      }
+    }
+  }
+  return distance != UINT_MAX;
+}
+
+WeightResult DistanceCalculator::tryGetLocalWeight(
+    KInstruction *pc, KInstruction *initPC, BasicBlock *pcBlock,
+    BasicBlock *prevPCBlock, weight_type &weight,
+    const std::vector<KBlock *> &localTargets, ref<Target> target) {
+  KFunction *currentKF = pc->parent->parent;
+  KBlock *initKB = initPC->parent;
+  KBlock *currentKB = currentKF->blockMap[pcBlock];
+  KBlock *prevKB = currentKF->blockMap[prevPCBlock];
+  const std::unordered_map<KBlock *, unsigned> &dist =
+      codeGraphDistance.getDistance(currentKB);
+  weight = UINT_MAX;
+  for (auto &end : localTargets) {
+    if (dist.count(end) > 0) {
+      unsigned int w = dist.at(end);
+      weight = std::min(w, weight);
+    }
+  }
+
+  if (weight == UINT_MAX)
+    return Miss;
+  if (weight == 0 && (initKB == currentKB || prevKB != currentKB ||
+                      target->shouldFailOnThisTarget())) {
+    return Done;
+  }
+
+  return Continue;
+}
+
+WeightResult DistanceCalculator::tryGetPreTargetWeight(
+    KInstruction *pc, KInstruction *initPC, BasicBlock *pcBlock,
+    BasicBlock *prevPCBlock, weight_type &weight,
+    const std::unordered_map<KFunction *, unsigned int>
+        &distanceToTargetFunction,
+    ref<Target> target) {
+  KFunction *currentKF = pc->parent->parent;
+  std::vector<KBlock *> localTargets;
+  for (auto &kCallBlock : currentKF->kCallBlocks) {
+    for (auto &calledFunction : kCallBlock->calledFunctions) {
+      KFunction *calledKFunction =
+          currentKF->parent->functionMap[calledFunction];
+      if (distanceToTargetFunction.count(calledKFunction) > 0) {
+        localTargets.push_back(kCallBlock);
+      }
+    }
+  }
+
+  if (localTargets.empty())
+    return Miss;
+
+  WeightResult res = tryGetLocalWeight(pc, initPC, pcBlock, prevPCBlock, weight,
+                                       localTargets, target);
+  return res == Done ? Continue : res;
+}
+
+WeightResult DistanceCalculator::tryGetPostTargetWeight(
+    KInstruction *pc, KInstruction *initPC, BasicBlock *pcBlock,
+    BasicBlock *prevPCBlock, weight_type &weight, ref<Target> target) {
+  KFunction *currentKF = pc->parent->parent;
+  std::vector<KBlock *> &localTargets = currentKF->returnKBlocks;
+
+  if (localTargets.empty())
+    return Miss;
+
+  WeightResult res = tryGetLocalWeight(pc, initPC, pcBlock, prevPCBlock, weight,
+                                       localTargets, target);
+  return res == Done ? Continue : res;
+}
+
+WeightResult DistanceCalculator::tryGetTargetWeight(
+    KInstruction *pc, KInstruction *initPC, BasicBlock *pcBlock,
+    BasicBlock *prevPCBlock, weight_type &weight, ref<Target> target) {
+  std::vector<KBlock *> localTargets = {target->getBlock()};
+  WeightResult res = tryGetLocalWeight(pc, initPC, pcBlock, prevPCBlock, weight,
+                                       localTargets, target);
+  return res;
+}

--- a/lib/Core/DistanceCalculator.h
+++ b/lib/Core/DistanceCalculator.h
@@ -1,0 +1,83 @@
+//===-- DistanceCalculator.h ------------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KLEE_DISTANCE_CALCULATOR_H
+#define KLEE_DISTANCE_CALCULATOR_H
+
+#include "ExecutionState.h"
+
+namespace llvm {
+class BasicBlock;
+} // namespace llvm
+
+namespace klee {
+class CodeGraphDistance;
+struct Target;
+
+enum WeightResult : std::uint8_t {
+  Continue,
+  Done,
+  Miss,
+};
+
+using weight_type = unsigned;
+
+struct DistanceResult {
+  WeightResult result;
+  weight_type weight;
+  bool isInsideFunction;
+
+  explicit DistanceResult(WeightResult result_, weight_type weight_ = 0,
+                          bool isInsideFunction_ = true)
+      : result(result_), weight(weight_), isInsideFunction(isInsideFunction_) {}
+};
+
+class DistanceCalculator {
+public:
+  explicit DistanceCalculator(CodeGraphDistance &codeGraphDistance_)
+      : codeGraphDistance(codeGraphDistance_) {}
+
+  DistanceResult getDistance(ExecutionState &es, ref<Target> target);
+  DistanceResult getDistance(KInstruction *pc, KInstruction *prevPC,
+                             KInstruction *initPC,
+                             const ExecutionState::stack_ty &stack,
+                             ReachWithError error, ref<Target> target);
+
+private:
+  CodeGraphDistance &codeGraphDistance;
+
+  bool distanceInCallGraph(KFunction *kf, KBlock *kb, unsigned int &distance,
+                           const std::unordered_map<KFunction *, unsigned int>
+                               &distanceToTargetFunction,
+                           ref<Target> target);
+  WeightResult tryGetLocalWeight(KInstruction *pc, KInstruction *initPC,
+                                 llvm::BasicBlock *pcBlock,
+                                 llvm::BasicBlock *prevPCBlock,
+                                 weight_type &weight,
+                                 const std::vector<KBlock *> &localTargets,
+                                 ref<Target> target);
+  WeightResult
+  tryGetPreTargetWeight(KInstruction *pc, KInstruction *initPC,
+                        llvm::BasicBlock *pcBlock,
+                        llvm::BasicBlock *prevPCBlock, weight_type &weight,
+                        const std::unordered_map<KFunction *, unsigned int>
+                            &distanceToTargetFunction,
+                        ref<Target> target);
+  WeightResult tryGetTargetWeight(KInstruction *pc, KInstruction *initPC,
+                                  llvm::BasicBlock *pcBlock,
+                                  llvm::BasicBlock *prevPCBlock,
+                                  weight_type &weight, ref<Target> target);
+  WeightResult tryGetPostTargetWeight(KInstruction *pc, KInstruction *initPC,
+                                      llvm::BasicBlock *pcBlock,
+                                      llvm::BasicBlock *prevPCBlock,
+                                      weight_type &weight, ref<Target> target);
+};
+} // namespace klee
+
+#endif /* KLEE_DISTANCE_CALCULATOR_H */

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -203,6 +203,8 @@ private:
 
 public:
   using stack_ty = std::vector<StackFrame>;
+  using TargetHashSet =
+      std::unordered_set<ref<Target>, RefTargetHash, RefTargetCmp>;
 
   // Execution - Control Flow specific
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -13,6 +13,7 @@
 #include "CXXTypeSystem/CXXTypeManager.h"
 #include "Context.h"
 #include "CoreStats.h"
+#include "DistanceCalculator.h"
 #include "ExecutionState.h"
 #include "ExternalDispatcher.h"
 #include "GetElementPtrTypeIterator.h"
@@ -446,6 +447,7 @@ Executor::Executor(LLVMContext &ctx, const InterpreterOptions &opts,
       specialFunctionHandler(0), timers{time::Span(TimerInterval)},
       concretizationManager(new ConcretizationManager(EqualitySubstitution)),
       codeGraphDistance(new CodeGraphDistance()),
+      distanceCalculator(new DistanceCalculator(*codeGraphDistance)),
       targetedExecutionManager(*codeGraphDistance), replayKTest(0),
       replayPath(0), usingSeeds(0), atMemoryLimit(false), inhibitForking(false),
       haltExecution(HaltExecution::NotHalt), ivcEnabled(false),
@@ -4182,7 +4184,7 @@ void Executor::targetedRun(ExecutionState &initialState, KBlock *target,
   states.insert(&initialState);
 
   TargetedSearcher *targetedSearcher =
-      new TargetedSearcher(Target::create(target), *codeGraphDistance);
+      new TargetedSearcher(Target::create(target), *distanceCalculator);
   searcher = targetedSearcher;
 
   std::vector<ExecutionState *> newStates(states.begin(), states.end());
@@ -4522,6 +4524,8 @@ void Executor::terminateStateOnExecError(ExecutionState &state,
 void Executor::terminateStateOnSolverError(ExecutionState &state,
                                            const llvm::Twine &message) {
   terminateStateOnError(state, message, StateTerminationType::Solver, "");
+  SetOfStates states = {&state};
+  decreaseConfidenceFromStoppedStates(states, HaltExecution::MaxSolverTime);
 }
 
 // XXX shoot me

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -70,6 +70,7 @@ class AddressManager;
 class Array;
 struct Cell;
 class CodeGraphDistance;
+class DistanceCalculator;
 class ExecutionState;
 class ExternalDispatcher;
 class Expr;
@@ -142,6 +143,7 @@ private:
   std::unique_ptr<ConcretizationManager> concretizationManager;
   std::unique_ptr<PForest> processForest;
   std::unique_ptr<CodeGraphDistance> codeGraphDistance;
+  std::unique_ptr<DistanceCalculator> distanceCalculator;
   std::unique_ptr<TargetCalculator> targetCalculator;
 
   /// Used to track states that have been added during the current

--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -19,7 +19,6 @@
 #include "klee/ADT/DiscretePDF.h"
 #include "klee/ADT/RNG.h"
 #include "klee/ADT/WeightedQueue.h"
-#include "klee/Module/CodeGraphDistance.h"
 #include "klee/Module/InstructionInfoTable.h"
 #include "klee/Module/KInstruction.h"
 #include "klee/Module/KModule.h"
@@ -150,133 +149,15 @@ static unsigned int ulog2(unsigned int val) {
 ///
 
 TargetedSearcher::TargetedSearcher(ref<Target> target,
-                                   CodeGraphDistance &_distance)
+                                   DistanceCalculator &_distanceCalculator)
     : states(std::make_unique<
              WeightedQueue<ExecutionState *, ExecutionStateIDCompare>>()),
-      target(target), codeGraphDistance(_distance),
-      distanceToTargetFunction(
-          codeGraphDistance.getBackwardDistance(target->getBlock()->parent)) {}
+      target(target), distanceCalculator(_distanceCalculator) {}
 
 ExecutionState &TargetedSearcher::selectState() { return *states->choose(0); }
 
-bool TargetedSearcher::distanceInCallGraph(KFunction *kf, KBlock *kb,
-                                           unsigned int &distance) {
-  distance = UINT_MAX;
-  const std::unordered_map<KBlock *, unsigned> &dist =
-      codeGraphDistance.getDistance(kb);
-  KBlock *targetBB = target->getBlock();
-  KFunction *targetF = targetBB->parent;
-
-  if (kf == targetF && dist.count(targetBB) != 0) {
-    distance = 0;
-    return true;
-  }
-
-  for (auto &kCallBlock : kf->kCallBlocks) {
-    if (dist.count(kCallBlock) != 0) {
-      for (auto &calledFunction : kCallBlock->calledFunctions) {
-        KFunction *calledKFunction = kf->parent->functionMap[calledFunction];
-        if (distanceToTargetFunction.count(calledKFunction) != 0 &&
-            distance > distanceToTargetFunction.at(calledKFunction) + 1) {
-          distance = distanceToTargetFunction.at(calledKFunction) + 1;
-        }
-      }
-    }
-  }
-  return distance != UINT_MAX;
-}
-
-TargetedSearcher::WeightResult
-TargetedSearcher::tryGetLocalWeight(ExecutionState *es, weight_type &weight,
-                                    const std::vector<KBlock *> &localTargets) {
-  unsigned int intWeight = es->steppedMemoryInstructions;
-  KFunction *currentKF = es->pc->parent->parent;
-  KBlock *initKB = es->initPC->parent;
-  KBlock *currentKB = currentKF->blockMap[es->getPCBlock()];
-  KBlock *prevKB = currentKF->blockMap[es->getPrevPCBlock()];
-  const std::unordered_map<KBlock *, unsigned> &dist =
-      codeGraphDistance.getDistance(currentKB);
-  unsigned int localWeight = UINT_MAX;
-  for (auto &end : localTargets) {
-    if (dist.count(end) > 0) {
-      unsigned int w = dist.at(end);
-      localWeight = std::min(w, localWeight);
-    }
-  }
-
-  if (localWeight == UINT_MAX)
-    return Miss;
-  if (localWeight == 0 && (initKB == currentKB || prevKB != currentKB ||
-                           target->shouldFailOnThisTarget())) {
-    return Done;
-  }
-
-  intWeight += localWeight;
-  weight = ulog2(intWeight); // number on [0,32)-discrete-interval
-  return Continue;
-}
-
-TargetedSearcher::WeightResult
-TargetedSearcher::tryGetPreTargetWeight(ExecutionState *es,
-                                        weight_type &weight) {
-  KFunction *currentKF = es->pc->parent->parent;
-  std::vector<KBlock *> localTargets;
-  for (auto &kCallBlock : currentKF->kCallBlocks) {
-    for (auto &calledFunction : kCallBlock->calledFunctions) {
-      KFunction *calledKFunction =
-          currentKF->parent->functionMap[calledFunction];
-      if (distanceToTargetFunction.count(calledKFunction) > 0) {
-        localTargets.push_back(kCallBlock);
-      }
-    }
-  }
-
-  if (localTargets.empty())
-    return Miss;
-
-  WeightResult res = tryGetLocalWeight(es, weight, localTargets);
-  weight = weight + 32; // number on [32,64)-discrete-interval
-  return res == Done ? Continue : res;
-}
-
-TargetedSearcher::WeightResult
-TargetedSearcher::tryGetPostTargetWeight(ExecutionState *es,
-                                         weight_type &weight) {
-  KFunction *currentKF = es->pc->parent->parent;
-  std::vector<KBlock *> &localTargets = currentKF->returnKBlocks;
-
-  if (localTargets.empty())
-    return Miss;
-
-  WeightResult res = tryGetLocalWeight(es, weight, localTargets);
-  weight = weight + 32; // number on [32,64)-discrete-interval
-  return res == Done ? Continue : res;
-}
-
-TargetedSearcher::WeightResult
-TargetedSearcher::tryGetTargetWeight(ExecutionState *es, weight_type &weight) {
-  std::vector<KBlock *> localTargets = {target->getBlock()};
-  WeightResult res = tryGetLocalWeight(es, weight, localTargets);
-  return res;
-}
-
-TargetedSearcher::WeightResult
-TargetedSearcher::tryGetWeight(ExecutionState *es, weight_type &weight) {
-  if (target->atReturn() && !target->shouldFailOnThisTarget()) {
-    if (es->prevPC->parent == target->getBlock() &&
-        es->prevPC == target->getBlock()->getLastInstruction()) {
-      return Done;
-    } else if (es->pc->parent == target->getBlock()) {
-      weight = 0;
-      return Continue;
-    }
-  }
-
-  if (target->shouldFailOnThisTarget() && target->isTheSameAsIn(es->prevPC) &&
-      target->isThatError(es->error)) {
-    return Done;
-  }
-
+WeightResult TargetedSearcher::tryGetWeight(ExecutionState *es,
+                                            weight_type &weight) {
   BasicBlock *bb = es->getPCBlock();
   KBlock *kb = es->pc->parent->parent->blockMap[bb];
   KInstruction *ki = es->pc;
@@ -285,51 +166,14 @@ TargetedSearcher::tryGetWeight(ExecutionState *es, weight_type &weight) {
       states->tryGetWeight(es, weight)) {
     return Continue;
   }
-  unsigned int minCallWeight = UINT_MAX, minSfNum = UINT_MAX, sfNum = 0;
-  for (auto sfi = es->stack.rbegin(), sfe = es->stack.rend(); sfi != sfe;
-       sfi++) {
-    unsigned callWeight;
-    if (distanceInCallGraph(sfi->kf, kb, callWeight)) {
-      callWeight *= 2;
-      if (callWeight == 0 && target->shouldFailOnThisTarget()) {
-        weight = 0;
-        return target->isTheSameAsIn(kb->getFirstInstruction()) &&
-                       target->isThatError(es->error)
-                   ? Done
-                   : Continue;
-      } else {
-        callWeight += sfNum;
-      }
 
-      if (callWeight < minCallWeight) {
-        minCallWeight = callWeight;
-        minSfNum = sfNum;
-      }
-    }
-
-    if (sfi->caller) {
-      kb = sfi->caller->parent;
-      bb = kb->basicBlock;
-    }
-    sfNum++;
-
-    if (minCallWeight < sfNum)
-      break;
+  auto distRes = distanceCalculator.getDistance(*es, target);
+  weight = ulog2(distRes.weight + es->steppedMemoryInstructions); // [0, 32]
+  if (!distRes.isInsideFunction) {
+    weight += 32; // [32, 64]
   }
 
-  WeightResult res = Miss;
-  if (minCallWeight == 0)
-    res = tryGetTargetWeight(es, weight);
-  else if (minSfNum == 0)
-    res = tryGetPreTargetWeight(es, weight);
-  else if (minSfNum != UINT_MAX)
-    res = tryGetPostTargetWeight(es, weight);
-  if (Done == res && target->shouldFailOnThisTarget()) {
-    if (!target->isThatError(es->error)) {
-      res = Continue;
-    }
-  }
-  return res;
+  return distRes.result;
 }
 
 void TargetedSearcher::update(
@@ -436,10 +280,10 @@ void TargetedSearcher::removeReached() {
 ///
 
 GuidedSearcher::GuidedSearcher(
-    CodeGraphDistance &codeGraphDistance, TargetCalculator &stateHistory,
+    DistanceCalculator &distanceCalculator, TargetCalculator &stateHistory,
     std::set<ExecutionState *, ExecutionStateIDCompare> &pausedStates,
     std::size_t bound, RNG &rng, Searcher *baseSearcher)
-    : baseSearcher(baseSearcher), codeGraphDistance(codeGraphDistance),
+    : baseSearcher(baseSearcher), distanceCalculator(distanceCalculator),
       stateHistory(stateHistory), pausedStates(pausedStates), bound(bound),
       theRNG(rng) {
   guidance = baseSearcher ? CoverageGuidance : ErrorGuidance;
@@ -833,7 +677,7 @@ bool GuidedSearcher::tryAddTarget(ref<TargetForest::History> history,
   assert(targetedSearchers.count(history) == 0 ||
          targetedSearchers.at(history).count(target) == 0);
   targetedSearchers[history][target] =
-      std::make_unique<TargetedSearcher>(target, codeGraphDistance);
+      std::make_unique<TargetedSearcher>(target, distanceCalculator);
   auto it = std::find_if(
       historiesAndTargets.begin(), historiesAndTargets.end(),
       [&history, &target](

--- a/lib/Core/Searcher.h
+++ b/lib/Core/Searcher.h
@@ -10,6 +10,7 @@
 #ifndef KLEE_SEARCHER_H
 #define KLEE_SEARCHER_H
 
+#include "DistanceCalculator.h"
 #include "ExecutionState.h"
 #include "PForest.h"
 #include "PTree.h"
@@ -34,13 +35,14 @@ class raw_ostream;
 } // namespace llvm
 
 namespace klee {
-class CodeGraphDistance;
+class DistanceCalculator;
 template <class T, class Comparator> class DiscretePDF;
 template <class T, class Comparator> class WeightedQueue;
 class ExecutionState;
 class Executor;
 class TargetCalculator;
 class TargetForest;
+class TargetReachability;
 
 /// A Searcher implements an exploration strategy for the Executor by selecting
 /// states for further exploration using different strategies or heuristics.
@@ -129,33 +131,17 @@ public:
 
 /// TargetedSearcher picks a state /*COMMENT*/.
 class TargetedSearcher final : public Searcher {
-public:
-  enum WeightResult : std::uint8_t {
-    Continue,
-    Done,
-    Miss,
-  };
-
 private:
-  typedef unsigned weight_type;
-
   std::unique_ptr<WeightedQueue<ExecutionState *, ExecutionStateIDCompare>>
       states;
   ref<Target> target;
-  CodeGraphDistance &codeGraphDistance;
-  const std::unordered_map<KFunction *, unsigned int> &distanceToTargetFunction;
+  DistanceCalculator &distanceCalculator;
   std::set<ExecutionState *> reachedOnLastUpdate;
 
-  bool distanceInCallGraph(KFunction *kf, KBlock *kb, unsigned int &distance);
-  WeightResult tryGetLocalWeight(ExecutionState *es, weight_type &weight,
-                                 const std::vector<KBlock *> &localTargets);
-  WeightResult tryGetPreTargetWeight(ExecutionState *es, weight_type &weight);
-  WeightResult tryGetTargetWeight(ExecutionState *es, weight_type &weight);
-  WeightResult tryGetPostTargetWeight(ExecutionState *es, weight_type &weight);
   WeightResult tryGetWeight(ExecutionState *es, weight_type &weight);
 
 public:
-  TargetedSearcher(ref<Target> target, CodeGraphDistance &distance);
+  TargetedSearcher(ref<Target> target, DistanceCalculator &distanceCalculator);
   ~TargetedSearcher() override;
 
   ExecutionState &selectState() override;
@@ -217,7 +203,7 @@ private:
   Guidance guidance;
   std::unique_ptr<Searcher> baseSearcher;
   TargetForestHistoryToSearcherMap targetedSearchers;
-  CodeGraphDistance &codeGraphDistance;
+  DistanceCalculator &distanceCalculator;
   TargetCalculator &stateHistory;
   TargetHashSet reachedTargets;
   std::set<ExecutionState *, ExecutionStateIDCompare> &pausedStates;
@@ -255,7 +241,7 @@ private:
 
 public:
   GuidedSearcher(
-      CodeGraphDistance &codeGraphDistance, TargetCalculator &stateHistory,
+      DistanceCalculator &distanceCalculator, TargetCalculator &stateHistory,
       std::set<ExecutionState *, ExecutionStateIDCompare> &pausedStates,
       std::size_t bound, RNG &rng, Searcher *baseSearcher = nullptr);
   ~GuidedSearcher() override = default;

--- a/lib/Core/UserSearcher.cpp
+++ b/lib/Core/UserSearcher.cpp
@@ -183,7 +183,7 @@ Searcher *klee::constructUserSearcher(Executor &executor,
       searcher = nullptr;
     }
     searcher = new GuidedSearcher(
-        *executor.codeGraphDistance.get(), *executor.targetCalculator,
+        *executor.distanceCalculator, *executor.targetCalculator,
         executor.pausedStates, MaxCycles - 1, executor.theRNG, searcher);
   }
 

--- a/lib/Module/TargetForest.cpp
+++ b/lib/Module/TargetForest.cpp
@@ -15,6 +15,8 @@
 #include "klee/Module/KModule.h"
 #include "klee/Module/TargetHash.h"
 
+#include "klee/Support/ErrorHandling.h"
+
 using namespace klee;
 using namespace llvm;
 
@@ -508,6 +510,14 @@ void TargetForest::blockIn(ref<Target> subtarget, ref<Target> target) {
     return;
   }
   forest = forest->blockLeafInChild(subtarget, target);
+}
+
+void TargetForest::block(const ref<Target> &target) {
+  if (!forest->deepFind(target)) {
+    return;
+  }
+
+  forest = forest->blockLeaf(target);
 }
 
 void TargetForest::dump() const {


### PR DESCRIPTION
Fix style

Add TargetReachability to update reachability of targets

Fix current confidence rates: check reachability for stucked states, decrease from solver timeouts and divide more during branch

Add skeleton for moving logic from searcher, without CoverageGuidance

Move isStuck to ExecutionState

Add handling of targetless states and reachedTargets

Add block method in target forest

Add history in ExecutionState

Add enum for guidance

Add first version of moving forest and distance calculation logic from searcher

Change ExecutionState * to uint32_t in reachability

Change interface of DistanceCalculator and pointer to reference

Move heuristic to distanceCalculator

Format

Fix

[fix]

<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 


## Checklist:
- [ ] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [ ] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [ ] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [ ] Each commit has a meaningful message documenting what it does.
- [ ] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [ ] The code is commented OR not applicable/necessary.
- [ ] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ ] There are test cases for the code you added or modified OR no such test cases are required.
